### PR TITLE
eplanner gets Moon separation wrong

### DIFF
--- a/scripts/eplanner.py
+++ b/scripts/eplanner.py
@@ -360,7 +360,7 @@ if __name__ == '__main__':
 
         # Compute minimum distance to the Moon during period target
         # is above airmass limit
-        seps = (star.position.separation(moon)).degree[ok]
+        seps = moon.separation(star.position).degree[ok]
         if len(seps):
             sepmin = seps.min()
             moon_close = sepmin < args.mdist


### PR DESCRIPTION
In astropy A.separation(B) calculates the separation in the reference frame of object A. ```get_moon``` gives the geocentric moon coordinates, but the targets are ICRS - so the code was calculating the moon-target separation as seen from the barycentre....